### PR TITLE
Change libupnp location and don't include mysql

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,5 @@ script:
   - brew tap gerbera/homebrew-gerbera
   - brew install gerbera
   - brew test duktape
-  - brew test libupnp
+  - brew test gerbera/gerbera/libupnp
   - brew test gerbera

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,7 @@ os:
   - osx
 script:
   - brew tap gerbera/homebrew-gerbera
-  - brew install duktape
-  - brew test duktape
-  - brew install libupnp
-  - brew upgrade --build-from-source gerbera/gerbera/libupnp
-  - brew test libupnp
   - brew install gerbera
+  - brew test duktape
+  - brew test libupnp
   - brew test gerbera

--- a/gerbera.rb
+++ b/gerbera.rb
@@ -10,7 +10,7 @@ class Gerbera < Formula
   depends_on "ffmpegthumbnailer"
   depends_on "libexif"
   depends_on "libmagic"
-  depends_on "libupnp"
+  depends_on "gerbera/gerbera/libupnp"
   depends_on "lzlib"
   depends_on "mysql"
   depends_on "ossp-uuid"
@@ -31,7 +31,7 @@ class Gerbera < Formula
       args << "-DCMAKE_CXX_COMPILER=/usr/bin/clang++"
       args << "-DCMAKE_INSTALL_PREFIX:PATH=#{prefix}"
       args << "-DWITH_FFMPEGTHUMBNAILER=1"
-      args << "-DWITH_MYSQL=1"
+      args << "-DWITH_MYSQL=0"
 
       system "cmake", "..", *args
       system "make", "install"

--- a/gerbera.rb
+++ b/gerbera.rb
@@ -12,7 +12,7 @@ class Gerbera < Formula
   depends_on "libmagic"
   depends_on "gerbera/gerbera/libupnp"
   depends_on "lzlib"
-  depends_on "mysql"
+  #depends_on "mysql"
   depends_on "ossp-uuid"
   depends_on "taglib"
 


### PR DESCRIPTION
Use gerbera/gerbera/libupnp to explicitly use the 1.8.3 version.
You can now run 
`brew tap gerbera/homebrew-gerbera`
`brew install gerbera`
to install gerbera.

No longer compile with MySQL support.