### PR TITLE
Change libupnp location and don't include mysql

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,16 @@
 language: none
 os:
   - osx
+  - osx_image: xcode9.4 # Xcode 9.4.1	OS X 10.13
 script:
   - brew tap gerbera/homebrew-gerbera
-  - brew install duktape
-  - brew test duktape
-  - brew install libupnp
-  - brew upgrade --build-from-source gerbera/gerbera/libupnp
-  - brew test libupnp
   - brew install gerbera
   - brew test gerbera
+  #- brew install duktape
+  #- brew test duktape
+  #- brew install libupnp
+  #- brew upgrade --build-from-source gerbera/gerbera/libupnp
+  #- brew test libupnp
+  #- brew install gerbera
+  #- brew test gerbera
+ 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,15 @@
 language: none
 os:
   - osx
+    osx_image: xcode9.4 # Xcode 9.4.1	OS X 10.13
 script:
   - brew tap gerbera/homebrew-gerbera
-  - brew install duktape
-  - brew test duktape
-  - brew install libupnp
-  - brew upgrade --build-from-source gerbera/gerbera/libupnp
-  - brew test libupnp
   - brew install gerbera
   - brew test gerbera
+  #- brew install duktape
+  #- brew test duktape
+  #- brew install libupnp
+  #- brew upgrade --build-from-source gerbera/gerbera/libupnp
+  #- brew test libupnp
+  #- brew install gerbera
+  #- brew test gerbera

--- a/gerbera.rb
+++ b/gerbera.rb
@@ -10,9 +10,8 @@ class Gerbera < Formula
   depends_on "ffmpegthumbnailer"
   depends_on "libexif"
   depends_on "libmagic"
-  depends_on "libupnp"
+  depends_on "gerbera/gerbera/libupnp"
   depends_on "lzlib"
-  depends_on "mysql"
   depends_on "ossp-uuid"
   depends_on "taglib"
 
@@ -31,7 +30,7 @@ class Gerbera < Formula
       args << "-DCMAKE_CXX_COMPILER=/usr/bin/clang++"
       args << "-DCMAKE_INSTALL_PREFIX:PATH=#{prefix}"
       args << "-DWITH_FFMPEGTHUMBNAILER=1"
-      args << "-DWITH_MYSQL=1"
+      args << "-DWITH_MYSQL=0"
 
       system "cmake", "..", *args
       system "make", "install"

--- a/gerbera.rb
+++ b/gerbera.rb
@@ -10,7 +10,7 @@ class Gerbera < Formula
   depends_on "ffmpegthumbnailer"
   depends_on "libexif"
   depends_on "libmagic"
-  depends_on "libupnp"
+  depends_on "gerbera/gerbera/libupnp"
   depends_on "lzlib"
   depends_on "mysql"
   depends_on "ossp-uuid"
@@ -31,7 +31,7 @@ class Gerbera < Formula
       args << "-DCMAKE_CXX_COMPILER=/usr/bin/clang++"
       args << "-DCMAKE_INSTALL_PREFIX:PATH=#{prefix}"
       args << "-DWITH_FFMPEGTHUMBNAILER=1"
-      args << "-DWITH_MYSQL=1"
+      args << "-DWITH_MYSQL=0"
 
       system "cmake", "..", *args
       system "make", "install"


### PR DESCRIPTION
Use gerbera/gerbera/libupnp to explicitly use the 1.8.3 version.
You can now run
`brew tap gerbera/homebrew-gerbera`
`brew install gerbera`
to install gerbera.

No longer compile with MySQL support.