### PR TITLE
Remove bottle block from libupnp formula

### DIFF
--- a/libupnp.rb
+++ b/libupnp.rb
@@ -4,13 +4,6 @@ class Libupnp < Formula
   url "https://downloads.sourceforge.net/project/pupnp/pupnp/libUPnP%201.8.3/libupnp-1.8.3.tar.bz2"
   sha256 "9afa0b09faa9ebd9e8a6425ddbfe8d1d856544c49b1f86fde221219e569a308d"
 
-  bottle do
-    cellar :any
-    sha256 "cbca37b45cb652c73d4c5ae0ae087338bb4c606f5be4306c5d998c39c382bb4b" => :high_sierra
-    sha256 "b870845572dd6d11ed90fedfb367bbd53066f6b9c90e522b97ce88ae53ccddfe" => :sierra
-    sha256 "9b660881232e6ce94a375962c1df55f179f69335c7d11907b9a9c5dd81693360" => :el_capitan
-  end
-
   option "without-ipv6", "Disable IPv6 support"
   option "without-reuseaddr", "Disable reuseaddr support"
 


### PR DESCRIPTION
So that `brew` won't attempt to find bottled 1.8.3 in Homebrew's Bintray
See [doc](https://github.com/Homebrew/brew/blob/master/docs/Bottles.md#root-url-root_url)